### PR TITLE
Add combo scoring and high score tracking with UI refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Index.html - loader screen
 Game.html - game file
 Countries.json - 2 char ISO identifier for each country - e.g. IE: Ireland
 Image Folder - country flags with ISO.PNG
+
+New Features:
+- Combo multiplier rewards consecutive correct answers.
+- High score is saved between sessions.

--- a/game.html
+++ b/game.html
@@ -28,6 +28,7 @@
   </div>
   <div id="feedback"></div>
   <div id="score">Score: 0</div>
+  <div id="multiplier">Combo: x1</div>
   <div id="round">Round: 1/10</div>
   <button id="restart-game" style="display: none;">Restart Game</button>
   <p></p>

--- a/index.html
+++ b/index.html
@@ -10,11 +10,16 @@
   <div class="title-container">
     <h1>FLAG FLAG FLAG</h1>
     <p>You have 10 rounds of 30 seconds to Guess the Flag. Points are scored based on how quickly you can answer.</p>
+    <div id="high-score">High Score: 0</div>
     <button id="start-button">Start Game</button>
   </div>
   <script>
-    document.getElementById('start-button').addEventListener('click', () => {
-      window.location.href = 'game.html';
+    document.addEventListener('DOMContentLoaded', () => {
+      const hs = localStorage.getItem('highScore') || 0;
+      document.getElementById('high-score').textContent = `High Score: ${hs}`;
+      document.getElementById('start-button').addEventListener('click', () => {
+        window.location.href = 'game.html';
+      });
     });
   </script>
     <div class="logo">

--- a/script.js
+++ b/script.js
@@ -13,6 +13,13 @@ document.addEventListener('DOMContentLoaded', () => {
   let timeLeft = timeLimit;
   let comboMultiplier = 1;
   let consecutiveCorrectAnswers = 0;
+  const maxMultiplier = 5;
+
+  const updateMultiplier = () => {
+    _('multiplier').textContent = `Combo: x${comboMultiplier}`;
+  };
+
+  updateMultiplier();
 
   // Fetch countries data from JSON file
   const fetchCountriesData = async () => {
@@ -63,10 +70,15 @@ document.addEventListener('DOMContentLoaded', () => {
         _('feedback').style.opacity = 1;
         consecutiveCorrectAnswers = 0;
         comboMultiplier = 1;
-        _('multiplier').textContent = `Combo Multiplier: x${comboMultiplier}`;
+        updateMultiplier();
         _('timer-container').classList.remove('flash'); // Remove flash class when time is up
         if (round >= totalRounds) {
-          _('feedback').textContent += ` Game over! Your final score is ${score}.`;
+          let highScore = parseInt(localStorage.getItem('highScore')) || 0;
+          if (score > highScore) {
+            localStorage.setItem('highScore', score);
+            highScore = score;
+          }
+          _('feedback').textContent += ` Game over! Your final score is ${score}. High Score: ${highScore}.`;
           _('restart-game').style.display = 'block'; // Show restart button
         } else {
           updateRound();
@@ -95,16 +107,26 @@ document.addEventListener('DOMContentLoaded', () => {
     const correctAnswer = countriesData[currentIndex].country.toLowerCase();
 
     if (userGuess === correctAnswer) {
-      score += timeLeft; // Score based on remaining time
+      consecutiveCorrectAnswers++;
+      comboMultiplier = Math.min(maxMultiplier, consecutiveCorrectAnswers);
+      score += timeLeft * comboMultiplier; // Score based on remaining time and multiplier
       _('feedback').style.color = 'var(--correct-color)';
       _('feedback').textContent = 'Correct!';
     } else {
       _('feedback').style.color = 'var(--wrong-color)';
       _('feedback').textContent = `Wrong! The correct answer was ${countriesData[currentIndex].country}.`;
+      consecutiveCorrectAnswers = 0;
+      comboMultiplier = 1;
     }
+    updateMultiplier();
     _('feedback').style.opacity = 1;
     if (round >= totalRounds) {
-      _('feedback').textContent += ` Game over! Your final score is ${score}.`;
+      let highScore = parseInt(localStorage.getItem('highScore')) || 0;
+      if (score > highScore) {
+        localStorage.setItem('highScore', score);
+        highScore = score;
+      }
+      _('feedback').textContent += ` Game over! Your final score is ${score}. High Score: ${highScore}.`;
       _('restart-game').style.display = 'block'; // Show restart button
     } else {
       updateRound();
@@ -128,10 +150,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const restartGame = () => {
     score = 0;
     round = 1;
+    comboMultiplier = 1;
+    consecutiveCorrectAnswers = 0;
     _('score').textContent = `Score: ${score}`;
     _('round').textContent = `Round: ${round}/${totalRounds}`;
     _('feedback').textContent = '';
     _('restart-game').style.display = 'none'; // Hide restart button
+    updateMultiplier();
     nextFlag();
   };
 

--- a/styles.css
+++ b/styles.css
@@ -16,7 +16,7 @@
 /* General Styles */
 body {
   margin: 0;
-  background-color: var(--background-color);
+  background: radial-gradient(circle at top, var(--background-color), #000000);
   color: var(--text-color);
   font-family: "Bebas Neue", sans-serif;
   display: flex;
@@ -58,6 +58,7 @@ body {
 
 #start-button:hover {
   background-color: var(--button-hover-bg);
+  transform: scale(1.05);
 }
 
 /* Game Page Styles */
@@ -197,9 +198,15 @@ circle {
 
 #multiplier {
   z-index: 100;
-  color: white;
+  color: #ff9800;
   font-size: 24px;
   font-weight: bold;
+  margin-top: 10px;
+}
+
+#high-score {
+  color: rgb(0, 170, 255);
+  font-size: 32px;
   margin-top: 10px;
 }
 


### PR DESCRIPTION
## Summary
- Track consecutive correct answers with a combo multiplier that boosts scoring
- Persist and display high scores across sessions
- Polish layout with gradient background and improved hover styles

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b14167a88332a38b3801f043a3c0